### PR TITLE
ubuntu/Dockerfile: pin nix-installer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["2.17.0"]
+        version: ["2.16.1", "2.17.0"]
         variant: [ubuntu]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
-      - main
-    paths:
-      - "**/Dockerfile"
-      - ".github/workflows/ci.yml"
-
   pull_request:
     paths:
       - "**/Dockerfile"

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:latest
+ARG NIX_INSTALLER_VERSION=0.8.0
 ARG NIX_VERSION=2.17.0
 RUN apt update -y \
     && apt install curl git -y \
-    && curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
+    && curl --proto '=https' --tlsv1.2 -sSf -L https://github.com/DeterminateSystems/nix-installer/releases/download/v$NIX_INSTALLER_VERSION/nix-installer.sh | sh -s -- install linux \
        --nix-package-url https://releases.nixos.org/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz \
        --extra-conf "sandbox = false" \
        --init none \


### PR DESCRIPTION
There are some issues with auto-allocate-uids and certain environments which is enabled in later installer versions.